### PR TITLE
Punctuation & formatting update for downloads

### DIFF
--- a/Linaro.org/downloads/README.md
+++ b/Linaro.org/downloads/README.md
@@ -59,22 +59,26 @@ The [OpenDataPlane](http://www.opendataplane.org/) API has three implementations
 *** 
 ## Linaro Toolchain
 
-Linaro provides [GCC source archives](https://snapshots.linaro.org/components/toolchain/gcc-linaro/) as monthly snapshots of the Linaro GCC release branch, as well as quarterly releases of pre-built Linaro [GNU cross-toolchain binary archives](https://releases.linaro.org/components/toolchain/binaries/).
+Linaro provides monthly [GCC source archive](https://snapshots.linaro.org/components/toolchain/gcc-linaro/) snapshots of the current Linaro GCC release branch, as well as quarterly releases of pre-built Linaro [GNU cross-toolchain binary archives](https://releases.linaro.org/components/toolchain/binaries/).
 
 The following tables provide direct access to the most common Linux and bare-metal ABI variants of the Linaro binary cross-toolchain quarterly releases.  Both x86_64 Linux and Mingw32 (MS Windows compatible) host binaries are provided:
 
 #### Latest Linux Targetted Binary Toolchain Releases
-- **arm-linux-gnueabihf** _(32-bit ARMv7 Cortex-A, hard-float, little-endian)_ - ([Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/) / [Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/) / [Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/) / [Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/))
-- **armv8l-linux-gnueabihf** _(32-bit ARMv8 Cortex-A, hard-float, little-endian)_ - ([Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/) / [Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/armv8l-linux-gnueabihf/) / [Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/) / [Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/armv8l-linux-gnueabihf/))
-- **aarch64-linux-gnu** _(64-bit ARMv8 Cortex-A, little-endian)_ - ([Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/) / [Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-linux-gnu/) / [Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/) / [Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-linux-gnu/))
+|    |    |    |    |    |    |
+|:---|:---|:---|:---|:---|:----|
+|**arm-linux-gnueabihf**|_32-bit ARMv7 Cortex-A, hard-float, little-endian_|[Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/)|[Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/)|[Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/)|[Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/arm-linux-gnueabihf/)|
+|**armv8l-linux-gnueabihf**|_32-bit ARMv8 Cortex-A, hard-float, little-endian_|[Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/)|[Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/armv8l-linux-gnueabihf/)|[Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/)|[Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/armv8l-linux-gnueabihf/)|
+|**aarch64-linux-gnu**|_64-bit ARMv8 Cortex-A, little-endian_|[Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/)|[Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-linux-gnu/)|[Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/)|[Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-linux-gnu/)|
 
 #### Latest Bare-Metal Targetted Binary Toolchain Releases
-- **arm-eabi** _(32-bit ARMv7 Cortex-A, soft-float, little-endian)_ - ([Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/) / [Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/arm-eabi/) / [Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/) / [Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/arm-eabi/)) 
-- **aarch64-elf** _(64-bit ARMv8 Cortex-A, little-endian)_  - ([Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/) / [Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-elf/) / [Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/) / [Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-elf/))
+|    |    |    |    |    |    |
+|:---|:---|:---|:---|:---|:----|
+|**arm-eabi**|_32-bit ARMv7 Cortex-A, soft-float, little-endian_|[Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/)|[Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/arm-eabi/)|[Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/)|[Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/arm-eabi/)| 
+|**aarch64-elf**|_64-bit ARMv8 Cortex-A, little-endian_|[Release-Notes](https://releases.linaro.org/components/toolchain/binaries/latest/)|[Binaries](https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-elf/)|[Source](https://releases.linaro.org/components/toolchain/gcc-linaro/latest/)|[Sysroot](https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-elf/)|
 
 ***
 
-Interested in other target ABIs such as big-endian or soft-float little-endian? All toolchain target ABI and host variants can be seen [here](https://releases.linaro.org/components/toolchain/binaries/latest/). _Note that not all ABI and host variants are supported to the same degree. See the ([release-notes](https://releases.linaro.org/components/toolchain/binaries/latest/) for more information._ 
+Interested in other target ABIs such as big-endian or soft-float little-endian? All toolchain target ABI and host variants can be seen [here](https://releases.linaro.org/components/toolchain/binaries/latest/). _Note: Not all ABI and host variants are supported to the same degree. See the [release-notes](https://releases.linaro.org/components/toolchain/binaries/latest/) for more information._
 
 ***
 


### PR DESCRIPTION
Eliminated spurious '(' in Linaro Toolchain note.
Replaced bullet list with table for Linaro Toolchain release targets.
Updated phrasing in :Linaro Toolchain description.