### PR TITLE
downloads: Provide a download link for R-LCR

### DIFF
--- a/Linaro.org/downloads/README.md
+++ b/Linaro.org/downloads/README.md
@@ -25,7 +25,9 @@ The LSK is a version of kernel.org’s Long-Term Stable (LTS) release with new L
 
 ## Linaro Confectionary Release (LCR)
 
-R-LCR is a build of the Android Open Source Project (AOSP) from a stable “L” branch that includes platform support and other features. R-LCR includes the Android flavour of Linaro Stable Kernel (LSK) for all machine configurations.
+R-LCR is a build of the Android Open Source Project (AOSP) from a stable release branch that includes platform support and other features. R-LCR includes the Android flavour of Linaro Stable Kernel (LSK) for all machine configurations.
+
+- [R-LCR, Binaries](https://releases.linaro.org/android/reference-lcr/)
 
 ***
 


### PR DESCRIPTION
Without some form of download link then including a Linaro product on the downloads page is useless.

It was not immediately obvious to me whether we should link to https://releases.linaro.org/android/reference-lcr/ or whether we should enumerate the supported platforms and use links such as https://releases.linaro.org/android/reference-lcr/fvp/latest/ .

For now I have opted for the lower maintainance (but less user friendly) approach.