### PR TITLE
Added the new press releases to the homepage.

### DIFF
--- a/_data/featured-posts.yml
+++ b/_data/featured-posts.yml
@@ -1,3 +1,11 @@
+- title: Linaro announces launch of 96Boards AI Platform
+  url: /news/linaro-launches-96boards-ai-platform/
+  class: linaro
+  icon: Linaro-Logo_white-icon.svg
+- title: Linaro Announces OpenDataPlane Tiger Moth LTS Software 
+  url: /news/linaro-announces-opendataplane-tigermoth/
+  class: linaro-two
+  icon: Linaro-Logo_white-icon.svg
 - title: High Performance Computing and Linaro
   url: /blog/high-performance-computing-and-linaro/
   class: linaro


### PR DESCRIPTION
Added the OpenDataPlane and 96Boards.ai press releases to the home page.