### PR TITLE
Removed link to software downloads from Engineering section in nav

### DIFF
--- a/_core/README.md
+++ b/_core/README.md
@@ -6,8 +6,6 @@ keywords: Core, Engineering, Platform, User Platforms , Linux, Open Source, hard
 permalink: /engineering/core/
 director: Mike Holmes
 ---
-# Core Engineering
-
 As demand for Linaro's collaborative engineering has grown, the company has expanded rapidly.
 
 When founded in 2010, Linaro engineering was divided into three functions: Platform, Landing Teams and Working Groups. The Platform function was focused on the Linaro releases and consisted of Foundations, User Platforms and Infrastructure – all of which supported the delivery of the work from the Working Groups and Landing Teams. The landing teams worked to ensure compatibility and optimization of packages and overall releases on specific member hardware platforms and helped in the work of upstreaming vendor patches to the Linux kernel and other relevant projects. During the first phase of Linaro’s development there were three working groups: Kernel Consolidation, Toolchain Evolution and Mobile Middleware.

--- a/_core/ctt/README.md
+++ b/_core/ctt/README.md
@@ -14,6 +14,4 @@ related_initiatives:
   - "7"
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsPUr5SKVE9So5Y571DWSU4Y
 ---
-# Core Technologies & Tools
-
 The Core Technologies & Tools Group is comprised of the [Builds and Baselines (login required)](https://support.linaro.org/home), [LAVA software team (login required)](https://wiki.linaro.org/LAVA), [LAVA Lab team (login required)](https://wiki.linaro.org/LAVA/Team), [QA (login required)](https://wiki.linaro.org/Platform/QA), and Toolchain teams. Our mission is to engineer world class continuous integration systems through collaboration, that can be leveraged by Linaro, our members, and the community.

--- a/_core/kernel/README.md
+++ b/_core/kernel/README.md
@@ -13,8 +13,6 @@ related_initiatives:
   - "8"
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsNcK4cX5OS6d4--lQdz6Zws
 ---
-# Kernel
-
 The Kernel Working Group’s (KWG) primary focus is to be an active contributor to the upstream community and facilitate acceptance of our code into the Linux mainline kernel. Our goal is kernel consolidation - a single source tree with integrated support for multiple Arm SoCs and Arm-based platforms.
 
 The Kernel Working Group has been at the center of Linaro’s engineering work right from the beginning. The code churn created by multiple companies and individuals trying to upstream essentially the same code into kernel.org was one of the main reasons that Linaro was founded and Linus Torvalds famously complained about this shortly after Linaro’s founding:

--- a/_core/security/README.md
+++ b/_core/security/README.md
@@ -16,7 +16,6 @@ image:
   path: /assets/images/blog/meltdown-spectre-download-linaro.jpg
   name: meltdown-spectre-download-linaro.jpg  
 ---
-# Security
 The Linaro Security Working Group (SWG) was created to help ensure an optimised
 and efficient software ecosystem exists to support Arm Open Source Linux
 distributions on security related topics, and to accelerate the delivery of high

--- a/_core/toolchain/README.md
+++ b/_core/toolchain/README.md
@@ -6,6 +6,4 @@ related_projects:
   - "7"
 tech-lead: Maxim Kuvyrkov
 ---
-# Toolchain
-
 The Linaro Toolchain works on all aspects of system-level tools - the core development toolchain (compiler, assembler, linker, debugger), core system libraries (dynamic linker, c-library), emulation, profiling and analysis (oprofile, performance events) and instrumentation (ftrace). The team also provides Linaro toolchain binary releases and Linaro Toolchain package releases. Linaro Toolchain works directly with upstream communities: GCC, Binutils, GDB, glibc, LLVM, QEMU.

--- a/_core/virtualization/README.md
+++ b/_core/virtualization/README.md
@@ -7,7 +7,6 @@ keywords: KVM, QEMU, Arm, SVE, GIGv3
 permalink: /engineering/core/virtualization/
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsNoPiBTZxdyLtPPJDMQmztZ
 ---
-
 The Linaro virtualization team has achieved many of its goals, and undergone a number of recent staffing changes resulting in a reorganisation to align the remaining work more closely with its proponents or logical maintainer.
 
 In summary:

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -38,6 +38,8 @@ pages:
       options:
           - text: Overview
             url: /engineering/
+          - text: Developers
+            url: /developers/
           - text: Core
             url: /engineering/core/
             options:
@@ -57,12 +59,43 @@ pages:
                   url: /engineering/core/security/
           - text: Segment Groups
             url: /groups/
+            options:
+                - text: LEG
+                  url: /groups/leg/
+                - text: LNG
+                  url: /groups/lng/
+                - text: LHG
+                  url: /groups/lhg/
+                - text: LMG
+                  url: /groups/lmg/
+                - text: LITE
+                  url: /groups/lite/
           - text: Lead Projects
             url: /projects/
+            options:
+                - text: Mobile AOSP Optimization
+                  url: /projects/aosp/
+                - text: Reference Digital Media Platforms
+                  url: /projects/reference-digital-media-platforms-for-arm/
+                - text: Big Data
+                  url: /projects/bigdata/
+                - text: Mobile Power Management
+                  url: /projects/mobile-power-management/
+                - text: Arm Kernel Collaboration
+                  url: /projects/arm-kernel-collaboration/
+                - text: Open Source Arm Tools
+                  url: /projects/open-source-arm-tools/
+                - text: Open Source Security
+                  url: /projects/open-source-security/
+                - text: OpenDataPlane
+                  url: /projects/opendataplane/
+                - text: Reference Platforms
+                  url: /projects/reference-platforms/
           - text: Special Interest Groups
             url: /sig/
-          - text: Developers
-            url: /developers/
+            options:
+                - text: HPC
+                  url: /sig/hpc/
     - title: Services
       url: /services/
     - title: Latest

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -61,8 +61,6 @@ pages:
             url: /projects/
           - text: Special Interest Groups
             url: /sig/
-          - text: Software Downloads
-            url: /latest/downloads/
           - text: Developers
             url: /developers/
     - title: Services

--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -119,7 +119,6 @@
     "^/downloads/historic(/?|/index.html)$ /downloads/ [R,L,NC]",
     "^/downloads/leb-faq(/?|/index.html)$ /downloads/ [R,L,NC]",
     "^/downloads/pdf(/?|/index.html)$ /assets/downloads/$1 [R,L,NC]",
-    "^/developers(/?|/index.html)$ /engineering/ [R,L,NC]",    
     "^/downloads(/?|/index.html)$ /latest/downloads/ [R,L,NC]",    
     "^/downloads/security(/?|/index.html)$ /latest/downloads/security/ [R,L,NC]",    
     "^/edge/96boards(/?|/index.html)$ / [R,L,NC]",

--- a/_groups/leg/README.md
+++ b/_groups/leg/README.md
@@ -33,8 +33,6 @@ members_key: leg_members
 redirect_from:
 - /leg/
 ---
-# Linaro Enterprise Group (LEG)
-
 The purpose of the Linaro Enterprise Group (LEG) is to collaborate and accelerate the development of foundational software for Arm Server Linux. LEG benefits have broad industry implications, including time to market acceleration, lower development costs, and access to innovative and differentiated systems, fundamental to the Arm ecosystem.
 
 The Linaro Enterprise Group (LEG) was established in November 2012 as the first segment focused group within Linaro. The group was established to accelerate Linux Arm server ecosystem development and it extended the list of Linaro members beyond Arm silicon vendors to Server OEM’s and commercial Linux providers.

--- a/_groups/lhg/README.md
+++ b/_groups/lhg/README.md
@@ -27,8 +27,6 @@ members_key: lhg_members
 redirect_from:
 - /lhg/
 ---
-# Linaro Home Group (LHG)
-
 The mission of the Linaro Digital Home Group (LHG) is to accelerate the adoption of Arm-based architectures in the digital home (entertainment) segment by working collaboratively on core Linux-based software platforms and delivering media via optimized and secure video frameworks. LHG works on solutions common to its members, namely those related to open source software for Arm-based set top boxes, smart TVs, media boxes, TV dongles and home gateway products.
 
 Consumers are not generally aware that they are using Linux and the number of different solutions means the market is badly fragmented and out of date kernels and distributions are still being actively marketed. This leads to high costs of integration, customization and maintenance; multiple media frameworks and players; and a lack of common interfaces and interoperability.

--- a/_groups/lite/README.md
+++ b/_groups/lite/README.md
@@ -20,8 +20,6 @@ members_key: lite_members
 redirect_from:
 - /lite/
 ---
-# Linaro IoT and Embedded (LITE)
-
 The Linaro IoT and Embedded Group (LITE) was launched at Linaro Connect LAS16 in September 2016. Companies interested in working together on common open source software foundations for IoT and embedded applications are invited to contact Linaro with the form below.
 
 The Internet of Things (IoT) is disrupting the traditional embedded market and  creating huge growth opportunities. Every device being connected to the cloud  and generating personal information is a huge data generation, connectivity and security headache. Standards are essential to the success of IoT and the LITE group will bring together Arm ecosystem support for key standards and engineering work to support reliable implementations.

--- a/_groups/lmg/README.md
+++ b/_groups/lmg/README.md
@@ -27,8 +27,6 @@ members_key: lmg_members
 redirect_from:
 - /lmg/
 ---
-# Linaro Mobile Group (LMG)
-
 Linaro was founded by companies focused on working together in the mobile space. As Linaro’s work broadened beyond mobile, discussions in the Technical Steering Committee (TSC) similarly broadened and towards the end of 2013, a mobile sub-committee (MOBSCOM) was formed to deal with mobile discussions in more detail. In July 2014, this sub-committee was replaced by the Linaro Mobile Group (LMG) and its associated steering committee (LMG-SC). Information about LMG is available on the Linaro wiki: https://wiki.linaro.org/LMG.
 
 Linaro’s mission in the mobile space has always been to collaborate with members to consolidate and optimize open source software for mobile platforms on Arm. The mobile space includes all types of phones, tablets, laptops and wearables. Android has been identified as the primary mobile OS on which Linaro’s work in this area is tested, but other options, including Chrome OS, Firefox OS and Tizen have been discussed and could be brought in if members decided there was a need.

--- a/_groups/lng/README.md
+++ b/_groups/lng/README.md
@@ -21,8 +21,6 @@ members_key: lng_members
 redirect_from:
 - /lng/
 ---
-# Linaro Networking Group (LNG)
-
 The Linaro Networking Group (LNG) is an autonomous segment focused group that is responsible for engineering development in the networking space. Some activities of this group may be of shared interest with other segments and conducted by another working group, e.g. much virtualization work is of interest to mobile, servers and networking and is conducted by the Virtualization working group. The LNG engineering team is divided into two groups: (Cloud) Infrastructure and OpenDataPlane.
 
 The portfolio, investment direction, themes, initiatives and value streams for LNG engineering activity are reviewed, approved/rejected and managed by the [LNG Steering Committee](https://wiki.linaro.org/LNG-SC) and [TSC](https://wiki.linaro.org/TSC/). The LNG engineering team is currently focused on delivery of the OpenDataPlane product. The current mix of LNG engineering activities includes:

--- a/_includes/developer-services-stacked-nav.html
+++ b/_includes/developer-services-stacked-nav.html
@@ -18,7 +18,7 @@
                                 <span class="icon-bar"></span>
                                 <span class="icon-bar"></span>
                             </button>
-                            <a class="navbar-brand" id="sub-navigation-header" href="">Developer Services Menu</a>
+                            <a class="navbar-brand" id="sub-navigation-header" href="">Navigation</a>
                         </div>
                         <div class="collapse navbar-collapse" id="stacked-nav-bar">
                             <ul class="nav nav-pills">

--- a/_layouts/developer-services.html
+++ b/_layouts/developer-services.html
@@ -30,10 +30,10 @@ css-package: developer-services
             </div>
 
             <div class="container" id="developer-services-content">
-                    <div class="col-lg-3 developer-services-side-bar-nav">
+                    <div class="col-sm-3 developer-services-side-bar-nav">
                             {% include developer-services-stacked-nav.html %}
                     </div>
-                    <div class="col-lg-9 main-developer-services-content">
+                    <div class="col-sm-9 main-developer-services-content">
                       <div id="developer-services-contact-modal" class="modal fade">
                                 <div class="modal-dialog modal-lg">
                                     <div class="modal-content">

--- a/_projects/README.md
+++ b/_projects/README.md
@@ -5,8 +5,6 @@ description: |-
     Linaro is a large engineering organization with many complex projects that map across various teams and groups.
 keywords: Mobile AOSP Optimization, Big Data, SDI, Mobile Power Management, Arm Kernel Collaboration, Open Source Arm Tools, Security, OpenDataPlane, ODP, specifications
 ---
-# Lead Projects
-
 Linaro is a large engineering organization with many complex projects that map across various teams and groups. Core and Vertical Segment Engineering groups have a limited number of Lead Projects that focus their collaborative work. In addition to Lead Projects, some of Linaro's output may result in the creation of an open source project, an API, hardware specifications or there may be higher level project areas that people regularly search for - this work is detailed in the [Initiatives](/initiatives/) section of this website.
 
 

--- a/_projects/aosp/README.md
+++ b/_projects/aosp/README.md
@@ -18,8 +18,6 @@ related_jira_projects:
     url: https://projects.linaro.org/projects/LMG/summary
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsMzB6auo_XJTwWeO20xyrDo
 ---
-# Mobile AOSP Optimization
-
 The Android Open Source Project (AOSP) is the foundation for Android based devices. It is a central goal to Linaro that the Arm based mobile ecosystem through AOSP, and more directly Android products, have a more superior user experience than Android products based on other CPU architectures.
 
 The Mobile AOSP Optimization Lead Project serves as the focus of LMG Engineering. The scope of Optimizations in this project covers the range of devices from those with modest amounts of memory and CPU(s) to those with more generous amounts of RAM with big/LITTLE SoC implementations. Optimizations do not refer to just those improvements in CPU performance but also include reducing the amount of RAM consumed by the system, improved Power Management, Thermal management, off-load to dedicated hardware, improvements that enable developers, I/O for Mobile form factors, file systems and so on.

--- a/_projects/arm-kernel-collaboration/README.md
+++ b/_projects/arm-kernel-collaboration/README.md
@@ -25,8 +25,6 @@ related_core_groups:
   - "1"
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsNnMSv7VFoaeZ1COZsx_-1v
 ---
-# Arm Kernel Collaboration
-
 Collaboration with Linaro and Member companies on upstreaming key common kernel features beneficial to the Arm Ecosystem.
 
 **The sources of the features could include:**

--- a/_projects/bigdata/README.md
+++ b/_projects/bigdata/README.md
@@ -9,8 +9,6 @@ related_groups:
   - "lmg"
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsNS43x2SWtSDsNrA1M4eEXq
 ---
-# Big Data
-
 Big Data Analytics is a pretty wide area that is experiencing a 100% growth rate every year, according to the keynotes from the last Hadoop Summit event. Big Data will continue growing as IoT gets closer to production deployment. The two main components are Hadoop and Spark. They fit the vision of scaling out the processing on as many compute nodes as available nicely, and are a perfect match to explore with Arm servers and a potential killer app. LEG Members have agreed to put together resources and focus on making AArch64 a first class citizen in the Hadoop / Spark community, and a well supported architecture for scale-out analytics.
 
 #### About OpenJDK:

--- a/_projects/mobile-power-management/README.md
+++ b/_projects/mobile-power-management/README.md
@@ -25,9 +25,6 @@ mailing_lists:
     url: https://lists.linaro.org/mailman/listinfo/sched-tools
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsPdiaNrIkWgl-x-fg48gJYV
 ---
-
-# Mobile Power Management
-
 Arm SoCs expose a lot of information to software about Hardware knobs for controlling power consumption. As there is no Hardware to OS abstraction layer (such as ACPI), these knobs tend to be controlled directly by OS drivers. Additionally, each SoC vendor exposes a superset of the standard Arm power states to allow fine-grained control over each component to maximize battery-life. This increases the complexity of the core SoC enablement code inside the kernel as well as the peripheral drivers.
 
 SoC vendors have taken slightly different approaches to implementing their OS power management frameworks. The differences arise for a number of reasons: a lack of design patterns to achieve what they require; due to lack of infrastructure support inside the kernel, and, on occasion, because of intrinsic differences in Hardware structure.

--- a/_projects/open-source-security/README.md
+++ b/_projects/open-source-security/README.md
@@ -20,7 +20,6 @@ related_initiatives:
   - "9"
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsMgprdH2L0zJ4LWWsBKB2h4
 ---
-# Open Source Security
 The Open Source Security Project (OSSP) is the main focus for Linaro's [Security Working Group (SWG)](/engineering/core/security/).
 
 In June 2017, the main elements of this project included kernel hardening, GlobalPlatform adaptations, TEE/TrustZone based open source trusted OS, security support for mcuboot in [LITE](/groups/lite/), and power management in a secure environment.

--- a/_projects/opendataplane/README.md
+++ b/_projects/opendataplane/README.md
@@ -28,8 +28,6 @@ governance:
     url: https://collaborate.linaro.org/pages/viewpage.action?pageId=47842677
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsP5AQz0xHG_vaMxbCVRM2jE
 ---
-# OpenDataPlane
-
 The OpenDataPlane project (ODP) is an open-source, cross-platform set of application programming interfaces (APIs) for the networking data plane. In October 2013, Linaro announced that it was collaborating with members of the Linaro Networking interest Group to develop and host an open standard application programming interface for data plane applications. Initially defined by members of the Linaro Networking Group (LNG), this project is open to contributions from all individuals and companies who share an interest in promoting a standard set of APIs to be used across the full range of network processor architectures available.
 
 ODP consists of an API specification and a set of reference implementations that realize these APIs on different platforms. Implementations range from pure software to those that deeply exploit the various hardware acceleration and offload features found on modern networking system-on-Chip (SoC) processors.

--- a/_projects/opensource-arm-tools/README.md
+++ b/_projects/opensource-arm-tools/README.md
@@ -28,8 +28,6 @@ mailing_lists:
     url: http://lists.linaro.org/mailman/listinfo/linaro-toolchain
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsM9fST9uSvNcP8miQeicKUn
 ---
-# Open Source Arm Tools
-
 The Toolchain Working Group deals with all aspects of system-level tools – the core development toolchain (compiler, assembler, linker, debugger), emulation, profiling and analysis (oprofile, performance events) and instrumentation (ftrace).
 
 **Key Deliverables:**

--- a/_projects/reference-digital-media-platforms-for-arm/README.md
+++ b/_projects/reference-digital-media-platforms-for-arm/README.md
@@ -17,8 +17,6 @@ engineering:
   - name: Developer Resources and Documentation
     url: https://wiki.linaro.org/LHG
 ---
-# Reference Digital Media Platforms for Arm
-
 This project has been defined to address the problem of defragmenting the media framework and associated security solutions that are currently found in the market.
 
 The project is focused on both the RDK and Android platforms, in the following areas:

--- a/_projects/reference-platforms/README.md
+++ b/_projects/reference-platforms/README.md
@@ -7,8 +7,6 @@ description: |-
 keywords: reference, releases, socs, source, hardware, tested, code, other, their, details
 youtube_playlist: https://www.youtube.com/playlist?list=PLKZSArYQptsMtUR_d-tgUpKW_ia7Ye_g5
 ---
-# Reference Platforms
-
 The goal of the [Reference Platforms](https://platforms.linaro.org/) Lead Project is to create reference end to end open source software releases for Arm SoCs in applications ranging from the Embedded to Enterprise segments. The releases comprise bootloader, kernel, distribution and user level middleware/applications. The intention is to make available reference source code, documentation on building the source code and any hardware dependencies including porting guide for other SoCs, and details about configurations chosen for the reference builds.
 
 The Reference Platform releases on their tested hardware are product quality. The tested hardware includes member SoCs, 96Boards products and may include some other third-party platforms. For further information, please visit [platforms.linaro.org](https://platforms.linaro.org/)

--- a/_sig/README.md
+++ b/_sig/README.md
@@ -6,8 +6,6 @@ description: |-
     In 2012, Linaro began to form Segment Groups that focused on new areas beyond the original mobile focus of Linaro's collaborative engineering.
 keywords: Linaro, Linux, SiG, Special Interest Group, LEG, Arm, HPC, High, Performance, Computing
 ---
-# Special Interest Group (SIG)
-
 In 2012, Linaro began to form Segment Groups that focused on new areas beyond the original mobile focus of Linaro's collaborative engineering. These groups have multiplied and grown and there are often specialist areas within the groups that are of specific interest to some of the members and potentially outside companies, but which are not of enough interest to the whole group to merit the investment of shared resources. To enable work to progress in those area, Linaro decided to allow the formation of Special Interest Groups (SIGs) inside the Segment Groups. The first of these - the High Performance Compute (HPC) SIG was formed in March 2017 in the Linaro Enterprise Group (LEG).
 
 If companies are interested in becoming members of Linaro and forming segment groups or SIGs, please do not hesitate to contact us with the form below.

--- a/_sig/hpc/README.md
+++ b/_sig/hpc/README.md
@@ -10,8 +10,6 @@ group_long_name: High Performance Computing (HPC)
 group_short_name: HPC
 icon: hpc-icon.svg
 ---
-# High Performance Computing (HPC)
-
 {% include media.html media_url="//www.slideshare.net/slideshow/embed_code/key/ztRPGcumfeBoru" %}
 
 The HPC SIG was officially launched at Linaro Connect Las Vegas in September 2016 to drive the adoption of Arm in HPC through the creation of a data center ecosystem. It is a collaborative project comprised of members and an advisory board. Current members include Arm, HiSilicon, Qualcomm, Fujitsu, Cavium, Red Hat and HXT. CERN and Riken are on the advisory board.

--- a/assets/css/app/developer-services.scss
+++ b/assets/css/app/developer-services.scss
@@ -279,15 +279,16 @@ div#stacked-nav-bar {
       width: 100%;
     }
 
-    a.dev-services.btn.btn-primary.btn-contact-developer-services {
-      margin-right: auto;
+    #wrapper a.dev-services.btn.btn-primary.btn-contact-developer-services {
+        margin-right: auto;
       display: block;
       position: relative;
       margin-top: 27px;
       line-height: 16px;
-      border-radius:0px;
+      border-radius: 0px;
       height: 35px;
       float: left !important;
+      top: -18px;
   }
 
     img.img-responsive.main-logo-developer-services.center-block {
@@ -364,9 +365,10 @@ div#stacked-nav-bar {
     .row.developer-services-contact-row {
         padding: 5px;
     }
-    a.btn-contact-developer-services {
-        top: -11px;
+    #wrapper a.btn-contact-developer-services {
+        top: -92px;
         border-top-right-radius: 0px;
+        margin-top: 0px;
     }
     .developer-services-content-title>h1 {
         font-size: 18px;


### PR DESCRIPTION
- Removed link to software downloads from Engineering section in nav
- Removed redirect from /developers/ to /engineering/
- Removed duplicated titles from the /engineering/ pages
- Updated the Developer Services section the section works 100% better on mobile and smaller screen sizes.