### PR TITLE
Fixed indentation issues with the description of Ebba's new blog post

### DIFF
--- a/_posts/2018/09/2018-09-07-the-emerging-ai-deep-learning-neural-network-ecosystem-and-why-we-need-to-collaborate.md
+++ b/_posts/2018/09/2018-09-07-the-emerging-ai-deep-learning-neural-network-ecosystem-and-why-we-need-to-collaborate.md
@@ -4,7 +4,7 @@ author: linaro
 layout: post
 date: 2018-09-07 09:00:00+00:00
 description: >-
-Linaro will be hosting an AI and Neural Networks on Arm Summit at the upcoming Linaro Connect Vancouver 2018 in one weeks time. This blog lists some of the great sessions being presented. 
+  Linaro will be hosting an AI and Neural Networks on Arm Summit at the upcoming Linaro Connect Vancouver 2018 in one weeks time. This blog lists some of the great sessions being presented.
 categories: blog
 tags: Arm, Linaro, Machine Learning, AI, Deep Learning, Neural Networks
 image:


### PR DESCRIPTION
Fixed indentation issues with the description of Ebba's new blog post. Indentation of the description must be set otherwise Jekyll fails to build post due to the the YAML error. @EbbaSimpson 