### PR TITLE
Replaced Cognito forms with a static contact button

### DIFF
--- a/_groups/README.md
+++ b/_groups/README.md
@@ -1,5 +1,5 @@
 ---
-title: Segment Groups
+title: Engineering Groups
 description: |-
     Linaro was established in 2010 to reduce fragmentation and redundant effort in open source software for mobile applications.
 keywords: Linaro, mobile, toolchain, middleware, open source, Android, code, validation, testing, Boards

--- a/_includes/linaro-contact-form.html
+++ b/_includes/linaro-contact-form.html
@@ -1,7 +1,7 @@
 {% unless page.url contains '/contact/' %}
     <hr />
 {% endunless %}
-<div class="col-xs-12">
+<div class="col-xs-12 text-center">
     <a class="btn email" href="mailto:contact@linaro.org?subject=Linaro.org - {{page.url}}">
         Contact Us
     </a>

--- a/_includes/linaro-contact-form.html
+++ b/_includes/linaro-contact-form.html
@@ -1,12 +1,10 @@
 {% unless page.url contains '/contact/' %}
     <hr />
 {% endunless %}
-<div class="cognito">
-    <script src="https://services.cognitoforms.com/s/KvRQmIn2dku6k6gGP711jw"></script>
-    <script>
-        Cognito.load("forms", { id: "7", entry: {
-          "PageUrl": "{{site.url}}{{page.url}}" ,
-          "RedirectUrl" : "{{site.url}}/thank-you/?ref={{page.url}}"
-        }});
-    </script>
+<div class="col-xs-12">
+    <a href="mailto:contact@linaro.org?subject=Linaro.org - {{page.url}}&">
+        <div class="email">
+            contact@linaro.org    
+        </div>
+    </a>
 </div>

--- a/_includes/linaro-contact-form.html
+++ b/_includes/linaro-contact-form.html
@@ -2,9 +2,7 @@
     <hr />
 {% endunless %}
 <div class="col-xs-12">
-    <a href="mailto:contact@linaro.org?subject=Linaro.org - {{page.url}}&">
-        <div class="email">
-            contact@linaro.org    
-        </div>
+    <a class="btn email" href="mailto:contact@linaro.org?subject=Linaro.org - {{page.url}}&">-        
+        Contact Us
     </a>
 </div>

--- a/_includes/linaro-contact-form.html
+++ b/_includes/linaro-contact-form.html
@@ -2,7 +2,7 @@
     <hr />
 {% endunless %}
 <div class="col-xs-12">
-    <a class="btn email" href="mailto:contact@linaro.org?subject=Linaro.org - {{page.url}}&">-        
+    <a class="btn email" href="mailto:contact@linaro.org?subject=Linaro.org - {{page.url}}">
         Contact Us
     </a>
 </div>

--- a/_includes/work-footer.html
+++ b/_includes/work-footer.html
@@ -22,18 +22,16 @@
     <ul class="list-unstyled">
       <li class="work_footer_li">
           <a href="/engineering/groups/">
-              <b>Segment Groups</b>
+              <b>Groups</b>
           </a>
       </li>
       {% assign groups = site.groups | sort: 'group_id' %}
       {% for segment_group in groups %}
-        {% if segment_group.output %}
           <li class="work_footer_li">
             <a href="{{segment_group.permalink}}">
               {{segment_group.title}}
             </a>
           </li>
-        {% endif %}
       {% endfor %}
     </ul>
 </div>

--- a/assets/css/app/contact.scss
+++ b/assets/css/app/contact.scss
@@ -21,4 +21,5 @@
 }
 .col-sm-8.contact{
     margin-top:50px;
+    margin-bottom:50px;
 }

--- a/assets/css/app/contact.scss
+++ b/assets/css/app/contact.scss
@@ -19,3 +19,6 @@
         height:200px;
     }    
 }
+.col-sm-8.contact{
+    margin-top:50px;
+}

--- a/assets/css/app/contact.scss
+++ b/assets/css/app/contact.scss
@@ -21,5 +21,5 @@
 }
 .col-sm-8.contact{
     margin-top:50px;
-    margin-bottom:50px;
+    margin-bottom:80px;
 }

--- a/assets/css/app/custom.scss
+++ b/assets/css/app/custom.scss
@@ -853,11 +853,11 @@ article.post-content>.col-md-8 {
 }
 
 // CSS for the email button.
-.email {
+#wrapper .email {
     height: 50px;
     background-color: #a4d23a;
     width: 200px;
-    line-height: 46px;
+    line-height: 30px;
     text-align: center;
     color: white;
     font-weight: bold;
@@ -866,7 +866,8 @@ article.post-content>.col-md-8 {
     margin-right: auto;
     transition: all 200ms ease;
 }
-.email:hover {
+#wrapper .email:hover {
     background-color: #3a3a3a;
     border: 1px solid #000000;
+    color:white;
 }

--- a/assets/css/app/custom.scss
+++ b/assets/css/app/custom.scss
@@ -851,3 +851,22 @@ article.post-content>.col-md-8 {
 #header-container h1, #header-container p {
     color: white;
 }
+
+// CSS for the email button.
+.email {
+    height: 50px;
+    background-color: #a4d23a;
+    width: 200px;
+    line-height: 46px;
+    text-align: center;
+    color: white;
+    font-weight: bold;
+    border: 1px solid #9e9e9e;
+    margin-left: auto;
+    margin-right: auto;
+    transition: all 200ms ease;
+}
+.email:hover {
+    background-color: #3a3a3a;
+    border: 1px solid #000000;
+}

--- a/assets/css/app/work.scss
+++ b/assets/css/app/work.scss
@@ -42,6 +42,14 @@ div#work_section {
     margin-bottom: 25px;
     border-bottom: 1px solid #eee;
 }
+img.img-responsive.group_icon {
+    display: block;
+    max-width: 80%;
+    height: 200px;
+    width: auto;
+    margin-left: auto;
+    margin-right: auto;
+}
 .group_members_img {
     width: auto;
     max-height: 100px;

--- a/contact/README.md
+++ b/contact/README.md
@@ -40,8 +40,6 @@ CB22 7GG <br>
 [Linaro Mailing List](/contact/mailing-list/)
 </div>
 
-
-
 <ul class="list-unstyled">
 <hr>
 <li markdown="1">
@@ -62,7 +60,7 @@ Website Legal page can be found [here](/legal/). For [media](/press/) enquiries:
 </ul>
 
 </div>
-<div class="col-sm-8">
+<div class="col-sm-8 contact">
 
 {% include linaro-contact-form.html %}
 

--- a/members-by-group/index.html
+++ b/members-by-group/index.html
@@ -15,14 +15,10 @@ css-package: members
 <br>
 {% include members.html data-file=site.data.members %}
 
-<div class="cognito fly">
-    <script src="https://services.cognitoforms.com/s/KvRQmIn2dku6k6gGP711jw"></script>
-    <script>
-        Cognito.load("forms", {
-            id: "14", entry: {
-                "PageUrl": "{{site.url}}{{page.url}}",
-                "RedirectUrl": "{{site.url}}/thank-you/?ref={{page.url}}",
-                "ChoiceField": [{% for member in site.data.members %}"{{member.membership_group_name}}"{% unless forloop.last %}, {% endunless %}{% endfor %}]
-            }});
-    </script>
+<h2 class="text-center fly">Become a member</h2>
+<hr>
+<div class="col-xs-12 text-center">
+    <a class="btn email fly" href="mailto:contact@linaro.org?subject=Linaro.org - Membership">
+        Apply to Join
+    </a>
 </div>

--- a/membership/README.md
+++ b/membership/README.md
@@ -132,17 +132,12 @@ There are multiple levels of membership and different ways to engage in projects
 </div>
 <div class="row padded-row" id="apply-to-join">
     <div class="container">
-        <h2 class="text-center fly">Apply to Join</h2>
-        <div class="cognito fly">
-            <script src="https://services.cognitoforms.com/s/KvRQmIn2dku6k6gGP711jw"></script>
-            <script>
-                Cognito.load("forms", {
-                    id: "14", entry: {
-                        "PageUrl": "{{site.url}}{{page.url}}",
-                        "RedirectUrl": "{{site.url}}/thank-you/?ref={{page.url}}",
-                        "ChoiceField": [{% for member in site.data.members %}"{{member.membership_group_name}}"{% unless forloop.last %}, {% endunless %}{% endfor %}]
-                    }});
-            </script>
+        <h2 class="text-center fly">Become a member</h2>
+        <hr>
+        <div class="col-xs-12 text-center">
+            <a class="btn email" href="mailto:contact@linaro.org?subject=Linaro.org - Membership">
+                Apply to Join
+            </a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
We are replacing the Cognito forms on our static websites with a simple contact button using a mailto: link and a pre filled subject line to automatically assign tickets which come in. This will allow us to track who is working on which ticket in the Service Desk portal.


