### PR TITLE
feeds: Avoid duplication when populating sortableFeeds

### DIFF
--- a/assets/js/app/planet.js
+++ b/assets/js/app/planet.js
@@ -30,24 +30,7 @@ var feeds = [
     "https://feedmix.novaclic.com/atom2rss.php?source=http%3A%2F%2Fthetestingcorner.com%2Ffeed.xml",
     "https://www.davidb.org/index.xml"
 ];
-var sortableFeeds = [
-    "https://linux.codehelp.co.uk/blog.xml",
-    "http://www.workofard.com/feed/",
-    "https://pierrchen.blogspot.com/rss.xml",
-    "http://www.metaklass.org/rss/",
-    "https://blog.sirena.org.uk/feed/",
-    "https://marcin.juszkiewicz.com.pl/feed/",
-    "https://fullshovel.wordpress.com/feed/",
-    "https://translatedcode.wordpress.com/feed/",
-    "http://suihkulokki.blogspot.com/feeds/posts/default/-/linaro",
-    "http://nerdrambles.wordpress.com/category/Linaro/feed/",
-    "http://www.bennee.com/~alex/blog/tag/linaro/feed/",
-    "https://station.eciton.net/index.rss",
-    "https://blog.duraffort.fr/feed/tag/linaro/rss",
-    "https://nbhat-ho2016.blogspot.co.uk/rss.xml",
-    "https://feedmix.novaclic.com/atom2rss.php?source=http%3A%2F%2Fthetestingcorner.com%2Ffeed.xml",
-    "https://www.davidb.org/index.xml"
-];
+var sortableFeeds = feeds.slice();
 // Collect Feed Channel Info
 var feedChannels = [];
 // Sort function which takes the data array, property to sort by and an asc boolean.


### PR DESCRIPTION
This is an experimental trick to see if we can avoid duplicating the feed list.
I'm afraid I have no clue how to test so I'm just throwing it over the wall.
I shall take no offence if the PR nacked ;-) .

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>