### PR TITLE
Temporary takedown of /engineering/projects/ section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -217,7 +217,7 @@ collections:
         output: true
         permalink: /:collection/:name/
     projects:
-        output: true
+        output: false
         permalink: /engineering/:collection/:path/
     services:
         output: true

--- a/_core/security/README.md
+++ b/_core/security/README.md
@@ -8,7 +8,7 @@ permalink: /engineering/core/security/
 principal-engineer: Joakim Bech
 projects:
   - title: OP-TEE
-    url: /engineering/projects/optee/
+    url: /engineering/projects/
 related_tags:
   - OP-TEE
   - Security

--- a/_core/toolchain/README.md
+++ b/_core/toolchain/README.md
@@ -5,7 +5,7 @@ permalink: /engineering/core/toolchain/
 tech-lead: Maxim Kuvyrkov
 projects:
   - title: GCC
-    url: /engineering/projects/gcc/
+    url: /engineering/projects/
 releases:
   - title: Toolchain Releases
     url: https://releases.linaro.org/components/toolchain/

--- a/_pages/engineering/README.md
+++ b/_pages/engineering/README.md
@@ -12,6 +12,8 @@ jumbotron:
         Linaro’s work spans a wide range of technologies. To find out more about what work we do in each vertical, click on the relevant icon below.
     title: Where Collaborative Engineering Happens
     background-image: /assets/images/content/engineering-bg.jpg
+redirect_from:
+ - /engineering/projects/
 ---
 <!--- Top Engineering Icons Row -->
 <div id="engineering-graphic" class="row" style="background-image:url('/assets/images/content/engineering-bg.svg')">

--- a/_pages/engineering/projects/index.md
+++ b/_pages/engineering/projects/index.md
@@ -3,7 +3,7 @@ title: Upstream Projects
 description: |-
     Linaro focuses much of its engineering work on contributing to existing upstream projects like the Linux Kernel and GNU Compiler Collection (GCC).
 keywords: Arm, GCC, GNU, Compiler, Automated, Validation, Architecture, Linux, Kernel, 96Boards
-permalink: /engineering/projects/
+permalink: /engineering/projects-temp/
 project: false
 css-package: projects
 layout: jumbotron-container

--- a/_pages/engineering/projects/index.md
+++ b/_pages/engineering/projects/index.md
@@ -29,7 +29,7 @@ and view stats on contributions.
     {% assign projectTextSize = project.title | size %}
     {% unless project.project_stats == "false" %}
         {% unless project.display == "false" %}
-            <a href="{{project.url}}">
+            <a hreff="{{project.url}}">
                 <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2 project-item {% if projectTextSize > 13 %}small-text{% endif %}">
                     {{project.title}} {% if project.project_stats != "false"%}<i class="fa fa-area-chart" aria-hidden="true"></i>{% endif %}
                 </div>
@@ -47,7 +47,7 @@ and view stats on contributions.
     {% assign projectTextSize = project.title | size %}
     {% if project.project_stats == "false" %}
     {% unless project.display == "false" %}
-    <a href="{{project.url}}">
+    <a hreff="{{project.url}}">
         <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2 project-item {% if projectTextSize > 13 %}small-text{% endif %}">
             {{project.title}}
         </div>

--- a/_posts/2016/07/2016-07-13-a-lava-landmark.markdown
+++ b/_posts/2016/07/2016-07-13-a-lava-landmark.markdown
@@ -49,7 +49,7 @@ What’s so special about V2? That is worthy of a blog post all on it’s own, b
 
 I’ll keep you posted.
 
-To find out more about LAVA, please follow this [link](/engineering/projects/lava/).
+To find out more about LAVA, please follow this [link](/engineering/projects/).
 
 Do you want to see how LAVA can help your company?
 

--- a/_posts/2017/12/2017-12-19-2017-year-in-review.md
+++ b/_posts/2017/12/2017-12-19-2017-year-in-review.md
@@ -40,7 +40,7 @@ Linaro core engineering consists of the Kernel, Power Management, Toolchain and 
 
 [**Toolchain**](/engineering/core/ctt/) - the team continued GNU releases, including GCC 7, GDB and GLIB, through the year, and continued work on LLVM. The OpenOCD AArch64 port was upstreamed.
 
-[**LAVA**](/engineering/projects/lava/) - LAVAv2 API support for KernelCI.org and support for LKFT (Google/LMG) was delivered alongside monthly LAVA releases. LAVA continues to see adoption in both member and community projects.
+[**LAVA**](/engineering/projects/) - LAVAv2 API support for KernelCI.org and support for LKFT (Google/LMG) was delivered alongside monthly LAVA releases. LAVA continues to see adoption in both member and community projects.
 
 </div>
 


### PR DESCRIPTION
Temporary takedown of /engineering/projects/ section while I work on  a fix for graph.js /stats endpoint issue.