### PR TITLE
Removing mentions of previous op-tee.org domains - member update pulled in to develop

### DIFF
--- a/_data/members.json
+++ b/_data/members.json
@@ -662,11 +662,6 @@
                 "image": "https://static.linaro.org/common/member-logos/neucore.jpg",
                 "name": "Shangahi Neucore Intelligent Technology Co Ltd.",
                 "url": "/membership/neucore/"
-            },
-            {
-                "image": "https://static.linaro.org/common/member-logos/framos.jpg",
-                "name": "Framos",
-                "url": "/membership/framos/"
             }
         ],
         "membership_group_name": "96Boards Manufacturing Partners",
@@ -695,6 +690,11 @@
                 "image": "https://static.linaro.org/common/member-logos/wizeiot.jpg",
                 "name": "WizeIoT",
                 "url": "/membership/wizeiot/"
+            },
+            {
+                "image": "https://static.linaro.org/common/member-logos/framos.jpg",
+                "name": "Framos",
+                "url": "/membership/framos/"
             }
         ],
         "membership_group_name": "96Boards Partners",

--- a/_pages/about/team/board/README.md
+++ b/_pages/about/team/board/README.md
@@ -46,6 +46,11 @@ team:
       Linaro on TI’s behalf since 2015. Jon holds a Bachelor of Science in
       Electrical Engineering from Rice University, and a Master of Science in
       Computer Science from the University of Houston.
+  - name: Bryan Huntsman
+    title: 'Board member for Qualcomm'
+    image: /assets/images/people/Bryan-Huntsman.jpg
+    bio: >-
+      Bryan Huntsman is a Senior Director at the Qualcomm Innovation Center and is responsible for Linux Kernel development on Qualcomm Snapdragon processors for mobile and IoT markets. Over the past nine years, he has set up a team of engineers and engineering processes that contributed to the launch of over a billion Android devices. Prior to joining Qualcomm, Bryan spent 10 years in the telecommunications industry working as a SW/FW developer for embedded, real-time systems. Bryan has a B.S in Computer Engineering from the University of Florida.
   - name: Stephen Li
     title: 'Board member for HiSilicon'
     image: /assets/images/people/stephen-li.jpg
@@ -58,8 +63,6 @@ team:
       Before joining Huawei Mr. Li held senior technical management positions in
       the embedded software industry, mostly at Wind River Systems, the provider
       of VxWorks OS.
-  - name: Mike Stefanick
-    title: Board member for Qualcomm
   - name: Rob Booth
     title: 'Board observer and COO, Linaro'
     image: /assets/images/people/Rob-Booth-72dpi1.jpg
@@ -74,13 +77,7 @@ team:
       Synomics a Bioinformatics software engineering company. His public company
       experience includes CFO of Tadpole Technology when it went public in 1992,
       where he and George Grey worked together. Rob is passionate about helping
-      build companies and generating maximum value from scarce resources.
-  - name: Bryan Huntsman
-    title: 'Board member for Qualcomm'
-    image: /assets/images/people/Bryan-Huntsman.jpg
-    bio: >-
-      Bryan Huntsman is a Senior Director at the Qualcomm Innovation Center and is responsible for Linux Kernel development on Qualcomm Snapdragon processors for mobile and IoT markets. Over the past nine years, he has set up a team of engineers and engineering processes that contributed to the launch of over a billion Android devices. Prior to joining Qualcomm, Bryan spent 10 years in the telecommunications industry working as a SW/FW developer for embedded, real-time systems. Bryan has a B.S in Computer Engineering from the University of Florida.
-        
+      build companies and generating maximum value from scarce resources.        
 ---
 
 The Board is the principal decision making body and focuses on ensuring the organization is moving toward its strategic mission through a combination of industry positioning, key partnerships, membership, and funding.

--- a/_posts/2018/02/2018-02-07-meltdown-spectre-2.markdown
+++ b/_posts/2018/02/2018-02-07-meltdown-spectre-2.markdown
@@ -49,7 +49,7 @@ We are not aware of any Meltdown and Spectre attacks on OP-TEE, in fact we are n
 
 Although TrustZone **is** affected by Meltdown and Spectre, we believe it is much harder to put the exploits in practice on secure side. One reason is that the SoC/OEMs are in full control of all software running on secure side on their devices (we still haven't seen any "appstore" for Trusted Application and it is probably quite unlikely that we will ever see one). I.e., all software on the secure side, the monitor, the TEE and the Trusted Applications are all signed (and verified during boot time or later when the system is up and running). Compare that a normal OS environment where anyone can write a program poking on who knows what. Another reason is that the execution path to secure side is "longer" and therefore we will get more "noise" in terms of cache lines being used by the code running between the attacker and the victim.
 
-Finally (with risk of being repetitive), all information about mitigation patches etc for OP-TEE can be found at our [security advisories](https://www.op-tee.org/security-advisories/) page at optee.org.
+Finally (with risk of being repetitive), all information about mitigation patches etc for OP-TEE can be found at our [security advisories](https://www.op-tee.org/security-advisories/) page at [op-tee.org](https://www.op-tee.org).
 
 # Arm Trusted Firmware
 


### PR DESCRIPTION
Removing mentions of previous op-tee.org domains - member update pulled in to develop