### PR TITLE
Remove unrequired env var

### DIFF
--- a/build-site.sh
+++ b/build-site.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 if [ -z "$JEKYLLSITEBUILD" ]; then
-        export JEKYLLSITEBUILD=latest
+  export JEKYLLSITEBUILD=latest
 fi
 
 if [ -z "$JEKYLL_ENV" ]; then
-	export JEKYLL_ENV=staging
+  export JEKYLL_ENV=staging
 fi
 docker run \
   --cap-drop ALL \
@@ -13,7 +13,6 @@ docker run \
   -t \
   -p 4000:4000 \
   -e JEKYLL_ACTION \
-  -e JEKYLL_CONFIG \
   -e JEKYLL_ENV \
   -v /etc/passwd:/etc/passwd:ro \
   -v /etc/group:/etc/group:ro \


### PR DESCRIPTION
JEKYLL_CONFIG isn't required now.

Also made spacing consistent.
