### PR TITLE
Build script improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _site
 .asset-cache
 .sass-cache
 .jekyll-metadata
+assets/resized
 production.linaro.org
 staging.linaro.org
 Gemfile.lock

--- a/build-site.sh
+++ b/build-site.sh
@@ -12,10 +12,18 @@ else
   PORTS=""
 fi
 
+# Are we running interactively or via Bamboo?
+if [ -t 1 ]; then
+  INTER="-i"
+else
+  INTER=""
+fi
+
 docker run \
   --cap-drop ALL \
   --rm \
   -t \
+  $INTER \
   $PORTS \
   -e JEKYLL_ACTION \
   -e JEKYLL_ENV \

--- a/build-site.sh
+++ b/build-site.sh
@@ -32,4 +32,4 @@ docker run \
   -u "$(id -u)":"$(id -g)" \
   -v "$(pwd)":/srv/source \
   linaroits/jekyllsitebuild:"$JEKYLLSITEBUILD" \
-  build-site.sh
+  build-site.sh "$@"


### PR DESCRIPTION
Check whether or not the script is being run interactively and pass any command-line arguments through to the container.

Ignore resized assets from the git repo index.
