### PR TITLE
Removing the no-padding class from the sidebar on company pages

### DIFF
--- a/_layouts/company.html
+++ b/_layouts/company.html
@@ -4,7 +4,7 @@ css-package: company
 js-package: blog
 ---
 {% if page.company_image %}
-<div class="col-xs-12 col-sm-3 col-sm-push-9 company-col no-padding text-center" markdown="1">
+<div class="col-xs-12 col-sm-3 col-sm-push-9 company-col text-center" markdown="1">
     <img class="img-responsive lazyload" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=="
         data-src="{{page.company_image}}" alt="{{page.title}} Image" />
     <div class="panel panel-default">


### PR DESCRIPTION
Removing the no-padding class from the sidebar on company pages