### PR TITLE
Updated theme version to fix robots.txt issue on staging sites

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 # Jekyll Theme
-gem 'jumbo-jekyll-theme', "5.6.5"
+gem 'jumbo-jekyll-theme', "5.6.6"
 # Jekyll Plugins
 group :jekyll_plugins do
    gem "jekyll-data"

--- a/robots.txt
+++ b/robots.txt
@@ -1,9 +1,0 @@
----
----
-{% if site.production %}
-User-agent: *
-Sitemap: {{site.url}}/sitemap.xml
-{% else %}
-User-agent: *
-Disallow: /
-{% endif %}


### PR DESCRIPTION
This PR updates the Jekyll theme version used by this site to fix the robots.txt issue whereby the disallow: * rule was not being added.