### PR TITLE
Removing duplicate key causing a YAML exception to be thrown by NetlifyCMS

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -798,8 +798,7 @@ collections:
         widget: list
         allow_add: true
         hint: "List your tags"
-        hint: "Your post category - limited to one category - multiple tags can be added however"
-      - {label: "Category", name: "category", widget: hidden, default: "News"}
+      - { label: "Category", name: "category", widget: hidden, default: "News"}
       - {
           label: 'Author',
           name: 'author',

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -323,7 +323,7 @@ collections:
                   - {label: Title, name: "name", widget: string, required: false}
                   - {label: Url, name: "url", widget: string, required: false}
           - label: "Last Column"
-            name: "last-column"
+            name: "third-column"
             widget: object
             required: false
             fields:


### PR DESCRIPTION
Removing duplicate key in the adming/config.yml file that is currently causing a YAML exception to be thrown by NetlifyCMS when accessing /admin/.