### PR TITLE
support: Minor tweaks (#961)

### DIFF
--- a/_includes/support_tabs.html
+++ b/_includes/support_tabs.html
@@ -24,7 +24,7 @@
                 are here to
                 guide and support you on Linaro’s software releases, contributions to open source and training material.
                 If you are
-                unsure whether you company has access to LDTS then visit <a
+                unsure whether your company has access to LDTS then visit <a
                     href="https://www.linaro.org/members-by-group/">our list
                     of members</a> and check if your company is a Core, Club or Group member.</p>
             <p>The scope of support we provide is very broad, reflecting the many different areas Linaro operates in.
@@ -45,7 +45,7 @@
         </div>
         <!--LDS Customers Tab -->
         <div role="tabpanel" class="tab-pane tab-pane-legal" id="lds-customers">
-            <p>Linaro Developer Technical Support is available to Linaro Developer Services customers at an additional
+            <p>Linaro Developer Technical Support is available to <a href="https://www.linaro.org/services/">Linaro Developer Services</a> customers at an additional
                 fee as part
                 of their contract. The scope of cover will vary depending on the contract and Statement of Work with
                 each individual
@@ -79,9 +79,8 @@
             <p>Additional Linaro Community Support can also be found at:</p>
             <ul>
                 <li><a href="http://www.linaro.org/engineering/getting-started">Getting Started</a></li>
-                <li><a href="https://wiki-archive.linaro.org/GettingInvolved/IRC">IRC</a></li>
+                <li><a href="https://www.linaro.org/contact/irc/">IRC</a></li>
                 <li><a href="http://www.linaro.org/engineering/mailing-lists">Mailing Lists</a></li>
-                <li><a href="https://wiki-archive.linaro.org/">Wiki</a></li>
                 <li><a href="http://www.linaro.org/linux-on-arm/community">Community</a></li>
                 <li><a href="http://www.linaro.org/downloads/">Downloads</a></li>
             </ul>


### PR DESCRIPTION
A couple of updates after a routine review:

 * Fix a small grammar error
 * Cross-link Linaro Developer Services where appropriate
 * Rip out links to wiki-archive.linaro.org (since they require a
   Linaro login they are no use to anyone in the community). One
   can be redirected but the other just needs to be removed.

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>