### PR TITLE
Adding the new Marvell Testimonial

### DIFF
--- a/_core/ctt/README.md
+++ b/_core/ctt/README.md
@@ -1,6 +1,10 @@
 ---
 core_id: "1"
 title: Core Technologies & Tools
+jumbotron:
+    title: Core Technologies & Tools
+    title-class: big-title
+    description: ""
 description: |-
     The Core Technologies & Tools Group is comprised of the Builds and Baselines, LAVA software team, LAVA Lab team, QA and Toolchain teams.
 keywords: Builds, Baselines, LAVA, software, Arm, collaboration, Toolchain, Continuous Integration, CI

--- a/_data/membership_testimonials.yml
+++ b/_data/membership_testimonials.yml
@@ -37,9 +37,9 @@ items:
       quote: >
         All members are focused around the Arm infrastructure and architecture. As a result, we are all looking for common optimisations and common environments to build on, regardless of whether we're targeting a server, networking or edge device.
       video:
-        mp4: https://static.linaro.org/videos/LarryWikeliusTestimonial.mp4
-        webm: https://static.linaro.org/videos/LarryWikeliusTestimonial.webm
-        ogv: https://static.linaro.org/videos/LarryWikeliusTestimonial.ogv
+        mp4: https://static.linaro.org/videos/marvell_testimonial.mp4
+        webm: https://static.linaro.org/videos/marvell_testimonial.webm
+        ogv: https://static.linaro.org/videos/marvell_testimonial.ogv
     - title: Kouichi Hirai - VP of Software Development at Fujitsu
       cover_image: /assets/images/content/kouichi-hirai-fujitsu-testimonial-screen.png
       attribution: Kouichi Hirai, Fujitsu

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -275,6 +275,8 @@ collections:
             fields:
                 - {label: Title, name: title, widget: string}
                 - {label: Cover Image, name: cover_image, widget: image}
+                - {label: Quote, name: quote, widget: text}
+                - {label: Attribution, name: attribution, widget: string, hint: "E.g Rob Oshana, NXP (used on the homepage testimonial slider"}
                 - label: Video
                   name: video
                   widget: object


### PR DESCRIPTION
Adding the new Marvell Testimonial
- updated the NetlifyCMS config for testimonials to include the attribution/quote fields
- update the membership_testimonials.yml data file with new URL
- added missing jumbotron front matter