### PR TITLE
Removing Old Redirect for PDF

### DIFF
--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -21,7 +21,6 @@
     "^/app/images/press/Rob_Booth_Hi_Res.jpg$ /assets/images/people/Rob_Booth_Hi_Res.jpg [R,L,NC]",
     "^/app/images/press/Steve_Taylor_72_dpi.jpg$ /assets/images/people/Steve_Taylor_72_dpi.jpg [R,L,NC]",
     "^/app/images/press/Steve_Taylor_Hi_Res.jpg$ /assets/images/people/Steve_Taylor_Hi_Res.jpg [R,L,NC]",
-    "^/app/resources/WhitePaper/VMSystemSpecificationForArm-v2.0.pdf$ /assets/downloads/VMSystemSpecificationForArm-v2.0.pdf [R,L,NC]",
     "^/apple-touch-icon-precomposed.png$ /assets/content/favicon.png [R,L,NC]",
     "^/apple-touch-icon.png$ /assets/content/favicon.png [R,L,NC]",
     "^/arm-freescale-ibm-samsung-st-ericsson-and-texas-instruments-form-new-company-to-speed-the-rollout-of-linux-based-devices(/?|/index.html)$ /news/arm-freescale-ibm-samsung-st-ericsson-and-texas-instruments-form-new-company-to-speed-the-rollout-of-linux-based-devices/ [R,L,NC]",


### PR DESCRIPTION
Removing Old Redirect for PDF - this is not used on the website and was causing an issue with Google Search Console.