### PR TITLE
Fixing blog page search

### DIFF
--- a/_posts/previous/2015-09-18-energy-aware-scheduling-eas-progress-update.md
+++ b/_posts/previous/2015-09-18-energy-aware-scheduling-eas-progress-update.md
@@ -3,10 +3,10 @@ author: linaro
 categories:
 - Blog
 date: 2015-09-18 19:01:52
-description: Arm and Linaro are jointly developing "Energy Aware Scheduling", a technique
+description: Arm and Linaro are jointly developing Energy Aware Scheduling, a technique
   that improves power management on Linux by making it more central and easier to
   tune. See the latest update.
-excerpt: Arm and Linaro are jointly developing "Energy Aware Scheduling", a technique
+excerpt: Arm and Linaro are jointly developing Energy Aware Scheduling, a technique
   that improves power management on Linux by making it more central and easier to
   tune. See the latest update.
 layout: post

--- a/assets/json/posts.json
+++ b/assets/json/posts.json
@@ -17,9 +17,9 @@ layout: null
         "tags": "{{ post.tags | join: ', ' }}",
         "url": "{{ site.baseurl }}{{ post.url }}",
         "description": "{% if post.description %}
-                            {{post.description}}
+                            {{post.description  | strip_html |  strip_newlines | remove_chars | escape}}
                         {% else %}
-                            {{ post.content | strip_html |  strip_newlines | remove_chars | escape | truncatewords:30 }}
+                            {{post.content | strip_html |  strip_newlines | remove_chars | escape | truncatewords:30}}
                         {% endif %}",
         "date": "{{ post.date | date: '%A, %B %-d, %Y' }}"
     } {% unless forloop.last %},


### PR DESCRIPTION
Fixing blog page search.

Posts.json was invalid causing the Simple Jekyll Search plugin to fail.