### PR TITLE
Changed the default image used for blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,6 +67,7 @@ defaults:
       layout: post
       is_post: true
       comments: true
+      image: /assets/images/content/code_banner.jpg
   - scope:
       path: ""
       type: "authors"


### PR DESCRIPTION
This PR sets a default image for the _posts folder in _config.yml. Previously posts without images had the screenshot of the homepage.