### PR TITLE
Escape full-stop on LHS to prevent looping

### DIFF
--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -82,7 +82,7 @@
   "^/blog/connect-update(/?|/index.html)$ /blog/$1 [R,L,NC]",
   "^/blog/core-dump(/?|/index.html)$ /blog/ [R,L,NC]",
   "^/blog/core-dump/(.*)$ /blog/$1 [R,L,NC]",
-  "^/blog/devicetree-specification-0.2-released(/?|/index.html)$ /blog/devicetree-specification-0_2-released/ [R,L,NC]",
+  "^/blog/devicetree-specification-0\\.2-released(/?|/index.html)$ /blog/devicetree-specification-0_2-released/ [R,L,NC]",
   "^/blog/energy-aware-scheduling-eas-project(/?|/index.html)$ /blog/ [R,L,NC]",
   "^/blog/evolution-of-a-generic-tee-kernel-driver-2(/?|/index.html)$ /blog/ [R,L,NC]",
   "^/blog/hangouts-on-air-update(/?|/index.html)$ /blog/$1 [R,L,NC]",


### PR DESCRIPTION
The full-stop matches any character. This means that when we redirect from, say, "2.0" to "2_0", that still matches because "." matches any character. We therefore need to "escape" the full-stop so that it is treated like a normal full-stop.
