### PR TITLE
Fix redirect loop

### DIFF
--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -82,7 +82,7 @@
   "^/blog/connect-update(/?|/index.html)$ /blog/$1 [R,L,NC]",
   "^/blog/core-dump(/?|/index.html)$ /blog/ [R,L,NC]",
   "^/blog/core-dump/(.*)$ /blog/$1 [R,L,NC]",
-  "^/blog/devicetree-specification-0\\.2-released(/?|/index.html)$ /blog/devicetree-specification-0_2-released/ [R,L,NC]",
+  "^/blog/devicetree-specification-0\\.2-released(/?|/index.html)$ https://github.com/devicetree-org/devicetree-specification/releases/tag/v0.2 [R,L,NC]",
   "^/blog/energy-aware-scheduling-eas-project(/?|/index.html)$ /blog/ [R,L,NC]",
   "^/blog/evolution-of-a-generic-tee-kernel-driver-2(/?|/index.html)$ /blog/ [R,L,NC]",
   "^/blog/hangouts-on-air-update(/?|/index.html)$ /blog/$1 [R,L,NC]",

--- a/_data/routingrules.json
+++ b/_data/routingrules.json
@@ -82,7 +82,7 @@
   "^/blog/connect-update(/?|/index.html)$ /blog/$1 [R,L,NC]",
   "^/blog/core-dump(/?|/index.html)$ /blog/ [R,L,NC]",
   "^/blog/core-dump/(.*)$ /blog/$1 [R,L,NC]",
-  "^/blog/devicetree-specification-0.2-released(/?|/index.html)$ /blog/devicetree-specification-0_2-released/ [R,L,NC]",
+  "^/blog/devicetree-specification-0\\.2-released(/?|/index.html)$ /blog/devicetree-specification-0_2-released/ [R,L,NC]",
   "^/blog/energy-aware-scheduling-eas-project(/?|/index.html)$ /blog/ [R,L,NC]",
   "^/blog/evolution-of-a-generic-tee-kernel-driver-2(/?|/index.html)$ /blog/ [R,L,NC]",
   "^/blog/hangouts-on-air-update(/?|/index.html)$ /blog/$1 [R,L,NC]",


### PR DESCRIPTION
It is necessary to change the endpoint link for this URL because the blog post doesn't exist.
